### PR TITLE
Using Cloudify plugin 4.0 instead of 3.3

### DIFF
--- a/function-test-openstack-blueprint.yaml
+++ b/function-test-openstack-blueprint.yaml
@@ -1,11 +1,11 @@
-tosca_definitions_version: cloudify_dsl_1_2
+tosca_definitions_version: cloudify_dsl_1_3
 
 description: >
   This blueprint is deploy target_vnf reference_vnf management_
   network and dataplane_network.
 
 imports:
-  - http://www.getcloudify.org/spec/cloudify/3.3/types.yaml
+  - http://www.getcloudify.org/spec/cloudify/4.0.1/types.yaml
   - http://www.getcloudify.org/spec/openstack-plugin/2.0.1/plugin.yaml
 
 inputs:


### PR DESCRIPTION
I order to fix this bug ([FUNCTEST-960](url)), we must use cloudify plugin 4.0 instead of 3.3