### PR TITLE
Remove the OpenStack plugin constraint

### DIFF
--- a/function-test-openstack-blueprint.yaml
+++ b/function-test-openstack-blueprint.yaml
@@ -6,7 +6,7 @@ description: >
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/4.0.1/types.yaml
-  - http://www.getcloudify.org/spec/openstack-plugin/2.0.1/plugin.yaml
+  - plugin:cloudify-openstack-plugin
 
 inputs:
   keystone_username:


### PR DESCRIPTION
OpenStack plugin 2.0.1 can't be installed.
The descriptor works vs the latest release.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>